### PR TITLE
Update index.tsx to point to actual release rather than old release

### DIFF
--- a/src/routes/Downloads/index.tsx
+++ b/src/routes/Downloads/index.tsx
@@ -10,7 +10,7 @@ const DownloadsRoute = () => {
         <div className="container">
           <h2>Download Bedrock Launcher</h2>
           <div className='button-group'>
-            <ButtonText type='link' to='https://github.com/BedrockLauncher/BedrockLauncher.Installer/releases/latest/download/BedrockLauncher.Installer.exe'>Lastest Version</ButtonText>
+            <ButtonText type='link' to='https://github.com/BedrockLauncher/BedrockLauncher/releases/tag/2022.7.4.195'>Lastest Version</ButtonText>
           </div>
         </div>
       </main>


### PR DESCRIPTION
Clicking download on current site points to the 0.0.2.1 release. This will send them to the current lite release download page